### PR TITLE
include biosphere activity information in tagged graph traversal

### DIFF
--- a/bw2analyzer/tagged.py
+++ b/bw2analyzer/tagged.py
@@ -195,6 +195,7 @@ Consider using `GraphTraversalLCA` from `bw2calc` instead."""
         "impact": outside_score,
         "biosphere": [
             {
+                "activity": exc.input,
                 "amount": exc["amount"] / scale * amount,
                 "impact": exc["amount"]
                 / scale


### PR DESCRIPTION
Because biosphere activities are humans too!
Also, with this information it is possible to see, which of the biosphere flows contributed how much to the impact.

Note: Could not run tests against this PR because of #9 .