### PR TITLE
Helper for labeled lca.inventory

### DIFF
--- a/bw2analyzer/lci.py
+++ b/bw2analyzer/lci.py
@@ -1,0 +1,34 @@
+import pandas as pd
+from bw2data import get_activity
+from bw2calc import LCA
+
+
+def get_labeled_inventory(lca: LCA) -> pd.DataFrame:
+    """
+    Take an LCA's inventory matrix and labels its rows (biosphere) and columns (technosphere) with activity metadata.
+
+    Args:
+        * *lca* (bw2calc.LCA): LCA object whose life cycle inventory has been calculated previously.
+
+    Returns:
+        pd.DataFrame with activity information as row and column MultiIndices.
+    """
+
+    assert hasattr(
+        lca, "inventory"
+    ), "Must calculate life cycle inventory first. Please call lci()."
+
+    rows = [
+        get_activity(lca.dicts.biosphere.reversed[i]).as_dict()
+        for i in range(lca.inventory.shape[0])
+    ]
+    columns = [
+        get_activity(lca.dicts.activity.reversed[i]).as_dict()
+        for i in range(lca.inventory.shape[1])
+    ]
+
+    return pd.DataFrame(
+        data=lca.inventory.todense(),
+        index=pd.MultiIndex.from_frame(pd.DataFrame(rows)),
+        columns=pd.MultiIndex.from_frame(pd.DataFrame(columns)),
+    )

--- a/tests/lci.py
+++ b/tests/lci.py
@@ -1,0 +1,84 @@
+from .tagged import tagged_fixture
+from bw2data import get_activity, methods
+from bw2calc import LCA
+from bw2analyzer.lci import get_labeled_inventory
+import pytest
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+
+def test_labeled_inventory_before_lci(tagged_fixture):
+    act = get_activity(("foreground", "fu"))
+    method = list(methods)[0]
+    lca = LCA({act: 1}, method)
+    with pytest.raises(AssertionError) as e_info:
+        get_labeled_inventory(lca)
+
+
+def test_labeled_inventory(tagged_fixture):
+    act = get_activity(("foreground", "fu"))
+    method = list(methods)[0]
+    lca = LCA({act: 1}, method)
+    lca.lci()
+    df = get_labeled_inventory(lca)
+
+    rows = [
+        {
+            "name": "bad",
+            "type": "emission",
+            "database": "biosphere",
+            "code": "bad",
+            "id": 1,
+        },
+        {
+            "name": "worse",
+            "type": "emission",
+            "database": "biosphere",
+            "code": "worse",
+            "id": 2,
+        },
+    ]
+    columns = [
+        {"database": "background", "code": "first", "id": 3},
+        {"database": "background", "code": "second", "id": 4},
+        {
+            "name": "functional unit",
+            "tag field": "functional unit",
+            "secondary tag": "X",
+            "database": "foreground",
+            "code": "fu",
+            "id": 5,
+        },
+        {
+            "tag field": "A",
+            "secondary tag": "X",
+            "database": "foreground",
+            "code": "i",
+            "id": 6,
+        },
+        {
+            "tag field": "C",
+            "secondary tag": "X",
+            "database": "foreground",
+            "code": "ii",
+            "id": 7,
+        },
+        {"database": "foreground", "code": "iii", "id": 8},
+        {
+            "tag field": "C",
+            "secondary tag": "Y",
+            "database": "foreground",
+            "code": "iv",
+            "id": 9,
+        },
+    ]
+    data = [
+        [30.0, 0.0, 0.0, 5.0, 16.0, 27.0, 0.0],
+        [0.0, 48.0, 0.0, 6.0, 14.0, 0.0, 44.0],
+    ]
+    expected = pd.DataFrame(
+        data=data,
+        index=pd.MultiIndex.from_frame(pd.DataFrame(rows)),
+        columns=pd.MultiIndex.from_frame(pd.DataFrame(columns)),
+    )
+    assert_frame_equal(df, expected)


### PR DESCRIPTION
Calculating life cycle inventories in brightway is nice and fast but interpreting the data is hard because lca.inventory contains no metadata about the biosphere and technosphere activities. I added a helper function, which reads the metadata of all rows and columns and adds them to the inventory data in one pandas.DataFrame.

- [x] black reformatted
- [x] includes tests
- [ ] requesting review by @cmutel 