### PR TITLE
continued work on `get_labeled_inventory`

### DIFF
--- a/bw2analyzer/lci.py
+++ b/bw2analyzer/lci.py
@@ -46,13 +46,12 @@ def get_labeled_inventory(
 
     Args:
         * *lca* (bw2calc.LCA): LCA object whose life cycle inventory has been calculated previously.
-        * *wide_format* (bool): Whether to return a pd.DataFrame in wide format (biosphere x technosphere)
-            or a pd.Series in long format ((biosphere x technosphere) x 1)
-        * *usecols* (None, 'all' or list of column names): which metadata fields to include in the indices.
-            None means default.
+        * *wide_format* (bool): Whether to return the labeled inventory table in wide format or narrow format (for an example see https://en.wikipedia.org/wiki/Wide_and_narrow_data).
+        * *usecols* (None, 'all' or list of column names): Which metadata fields to include in the indices. None means default.
 
     Returns:
-        pd.DataFrame with activity information as row and column MultiIndices.
+        If wide_format == True: pd.DataFrame with biosphere data as row index and technosphere data as column index.
+        If wide_format == False: pd.Series with biosphere (source) and technosphere (target) data as the index.
     """
 
     assert hasattr(

--- a/bw2analyzer/lci.py
+++ b/bw2analyzer/lci.py
@@ -1,14 +1,60 @@
 import pandas as pd
-from bw2data import get_activity
+from bw2data import Database
 from bw2calc import LCA
+from typing import List, Union
 
 
-def get_labeled_inventory(lca: LCA) -> pd.DataFrame:
+def _get_dependent_database_names(lca: LCA) -> List[str]:
+    databases = []
+    for key in lca.remapping_dicts.keys():
+        databases += [key[0] for key in lca.remapping_dicts[key].values()]
+    return pd.unique(databases)
+
+
+def _load_database_metadata(
+    lca: LCA, cols: Union[None, List[str], str] = None
+) -> pd.DataFrame:
+    # get database names
+    databases = _get_dependent_database_names(lca)
+    # load metadata and store in one dataframe
+    df = pd.DataFrame()
+    for db in databases:
+        df = df.append(pd.DataFrame(Database(db)), ignore_index=True)
+    # drop unwanted columns
+    if cols is None:
+        cols = [
+            "id",
+            "name",
+            "location",
+            "reference product",
+            "type",
+            "unit",
+            "database",
+            "categories",
+        ]
+    elif cols == "all":
+        cols = df.columns.tolist()
+    existing_cols = [c for c in cols if c in df]
+    df = df[existing_cols]
+    # set index
+    df = df.set_index("id")
+    return df
+
+
+def get_labeled_inventory(
+    lca: LCA,
+    wide_format: bool = True,
+    usecols: Union[None, List[str], str] = None,
+) -> Union[pd.DataFrame, pd.Series]:
     """
     Take an LCA's inventory matrix and labels its rows (biosphere) and columns (technosphere) with activity metadata.
 
     Args:
         * *lca* (bw2calc.LCA): LCA object whose life cycle inventory has been calculated previously.
+        * *wide_format* (bool): Whether to return a pd.DataFrame in wide format (biosphere x technosphere)
+            or a pd.Series in long format ((biosphere x technosphere) x 1)
+        * *usecols* (None, 'all' or list of column names): which metadata fields to include in the indices.
+            None means default.
 
     Returns:
         pd.DataFrame with activity information as row and column MultiIndices.
@@ -18,17 +64,63 @@ def get_labeled_inventory(lca: LCA) -> pd.DataFrame:
         lca, "inventory"
     ), "Must calculate life cycle inventory first. Please call lci()."
 
-    rows = [
-        get_activity(lca.dicts.biosphere.reversed[i]).as_dict()
-        for i in range(lca.inventory.shape[0])
-    ]
-    columns = [
-        get_activity(lca.dicts.activity.reversed[i]).as_dict()
-        for i in range(lca.inventory.shape[1])
-    ]
+    # get activity metadata
+    meta = _load_database_metadata(lca, usecols)
 
-    return pd.DataFrame(
-        data=lca.inventory.todense(),
-        index=pd.MultiIndex.from_frame(pd.DataFrame(rows)),
-        columns=pd.MultiIndex.from_frame(pd.DataFrame(columns)),
-    )
+    if wide_format:
+
+        # map local matrix indices to global database ids
+        rows_global = lca.dicts.biosphere.reversed.values()
+        cols_global = lca.dicts.activity.reversed.values()
+
+        # associate metadata, drop columns which are empty
+        row_meta = (
+            pd.DataFrame(index=rows_global, data=rows_global, columns=["id"])
+            .join(meta, how="left")
+            .dropna(how="all", axis=1)
+        )
+        col_meta = (
+            pd.DataFrame(index=cols_global, data=cols_global, columns=["id"])
+            .join(meta, how="left")
+            .dropna(how="all", axis=1)
+        )
+
+        # make dataframe with appropriate row and column indices
+        df = pd.DataFrame(
+            data=lca.inventory.todense(),
+            index=pd.MultiIndex.from_frame(row_meta),
+            columns=pd.MultiIndex.from_frame(col_meta),
+        )
+        return df
+    # return dataframe in long format
+    else:
+        rows, cols = lca.inventory.nonzero()
+
+        # map local matrix indices to global database ids
+        rows_global = [lca.dicts.biosphere.reversed[r] for r in rows]
+        cols_global = [lca.dicts.activity.reversed[c] for c in cols]
+
+        # filter metadata
+        row_meta = (
+            pd.DataFrame(index=rows_global, data=rows_global, columns=["id"])
+            .join(meta, how="left")
+            .reset_index(drop=True)
+        )
+        col_meta = (
+            pd.DataFrame(index=cols_global, data=cols_global, columns=["id"])
+            .join(meta, how="left")
+            .reset_index(drop=True)
+        )
+
+        # rename columns to avoid duplicate names for row and col
+        row_meta.columns = ["source_" + c for c in row_meta.columns]
+        col_meta.columns = ["target_" + c for c in col_meta.columns]
+
+        # combine row and column metadata, drop columns which are empty
+        index = pd.concat([row_meta, col_meta], axis=1).dropna(how="all", axis=1)
+        se = pd.Series(
+            index=pd.MultiIndex.from_frame(index),
+            data=lca.inventory.data,
+            name="value",
+        )
+        return se

--- a/tests/lci.py
+++ b/tests/lci.py
@@ -1,10 +1,156 @@
 from .tagged import tagged_fixture
 from bw2data import get_activity, methods
 from bw2calc import LCA
-from bw2analyzer.lci import get_labeled_inventory
+from bw2analyzer.lci import get_labeled_inventory, get_labeled_characterized_inventory
 import pytest
 import pandas as pd
 from pandas.testing import assert_frame_equal, assert_series_equal
+
+# naughty fixtures
+expected_wide_index = [
+    {
+        "id": 1,
+        "name": "bad",
+        "type": "emission",
+        "database": "biosphere",
+        "code": "bad",
+    },
+    {
+        "name": "worse",
+        "type": "emission",
+        "database": "biosphere",
+        "code": "worse",
+        "id": 2,
+    },
+]
+
+expected_wide_columns = [
+    {"id": 3, "database": "background", "code": "first"},
+    {"database": "background", "code": "second", "id": 4},
+    {
+        "id": 5,
+        "name": "functional unit",
+        "tag field": "functional unit",
+        "secondary tag": "X",
+        "database": "foreground",
+        "code": "fu",
+    },
+    {
+        "tag field": "A",
+        "secondary tag": "X",
+        "database": "foreground",
+        "code": "i",
+        "id": 6,
+    },
+    {
+        "tag field": "C",
+        "secondary tag": "X",
+        "database": "foreground",
+        "code": "ii",
+        "id": 7,
+    },
+    {"database": "foreground", "code": "iii", "id": 8},
+    {
+        "tag field": "C",
+        "secondary tag": "Y",
+        "database": "foreground",
+        "code": "iv",
+        "id": 9,
+    },
+]
+
+expected_narrow_index = index = [
+    {
+        "source_id": 1,
+        "source_code": "bad",
+        "source_database": "biosphere",
+        "source_name": "bad",
+        "source_type": "emission",
+        "target_id": 3,
+        "target_code": "first",
+        "target_database": "background",
+    },
+    {
+        "source_id": 1,
+        "source_code": "bad",
+        "source_database": "biosphere",
+        "source_name": "bad",
+        "source_type": "emission",
+        "target_id": 4,
+        "target_code": "second",
+        "target_database": "background",
+    },
+    {
+        "source_id": 1,
+        "source_code": "bad",
+        "source_database": "biosphere",
+        "source_name": "bad",
+        "source_type": "emission",
+        "target_id": 6,
+        "target_code": "i",
+        "target_database": "foreground",
+        "target_secondary tag": "X",
+        "target_tag field": "A",
+    },
+    {
+        "source_id": 1,
+        "source_code": "bad",
+        "source_database": "biosphere",
+        "source_name": "bad",
+        "source_type": "emission",
+        "target_id": 6,
+        "target_code": "i",
+        "target_database": "foreground",
+        "target_secondary tag": "X",
+        "target_tag field": "A",
+    },
+    {
+        "source_id": 2,
+        "source_code": "worse",
+        "source_database": "biosphere",
+        "source_name": "worse",
+        "source_type": "emission",
+        "target_id": 7,
+        "target_code": "ii",
+        "target_database": "foreground",
+        "target_secondary tag": "X",
+        "target_tag field": "C",
+    },
+    {
+        "source_id": 2,
+        "source_code": "worse",
+        "source_database": "biosphere",
+        "source_name": "worse",
+        "source_type": "emission",
+        "target_id": 7,
+        "target_code": "ii",
+        "target_database": "foreground",
+        "target_secondary tag": "X",
+        "target_tag field": "C",
+    },
+    {
+        "source_id": 2,
+        "source_code": "worse",
+        "source_database": "biosphere",
+        "source_name": "worse",
+        "source_type": "emission",
+        "target_id": 8,
+        "target_code": "iii",
+        "target_database": "foreground",
+    },
+    {
+        "source_id": 2,
+        "source_code": "worse",
+        "source_database": "biosphere",
+        "source_name": "worse",
+        "source_type": "emission",
+        "target_id": 9,
+        "target_code": "iv",
+        "target_database": "foreground",
+        "target_secondary tag": "Y",
+        "target_tag field": "C",
+    },
+]
 
 
 def test_labeled_inventory_before_lci(tagged_fixture):
@@ -22,67 +168,15 @@ def test_labeled_inventory_wide_format(tagged_fixture):
     lca.lci()
     df = get_labeled_inventory(lca, wide_format=True, usecols="all")
 
-    assert isinstance(df, pd.DataFrame)
-
-    rows = [
-        {
-            "id": 1,
-            "name": "bad",
-            "type": "emission",
-            "database": "biosphere",
-            "code": "bad",
-        },
-        {
-            "name": "worse",
-            "type": "emission",
-            "database": "biosphere",
-            "code": "worse",
-            "id": 2,
-        },
-    ]
-    columns = [
-        {"id": 3, "database": "background", "code": "first"},
-        {"database": "background", "code": "second", "id": 4},
-        {
-            "id": 5,
-            "name": "functional unit",
-            "tag field": "functional unit",
-            "secondary tag": "X",
-            "database": "foreground",
-            "code": "fu",
-        },
-        {
-            "tag field": "A",
-            "secondary tag": "X",
-            "database": "foreground",
-            "code": "i",
-            "id": 6,
-        },
-        {
-            "tag field": "C",
-            "secondary tag": "X",
-            "database": "foreground",
-            "code": "ii",
-            "id": 7,
-        },
-        {"database": "foreground", "code": "iii", "id": 8},
-        {
-            "tag field": "C",
-            "secondary tag": "Y",
-            "database": "foreground",
-            "code": "iv",
-            "id": 9,
-        },
-    ]
-    data = [
+    expected_data = [
         [30.0, 0.0, 0.0, 5.0, 16.0, 27.0, 0.0],
         [0.0, 48.0, 0.0, 6.0, 14.0, 0.0, 44.0],
     ]
     expected = (
         pd.DataFrame(
-            data=data,
-            index=pd.MultiIndex.from_frame(pd.DataFrame(rows)),
-            columns=pd.MultiIndex.from_frame(pd.DataFrame(columns)),
+            data=expected_data,
+            index=pd.MultiIndex.from_frame(pd.DataFrame(expected_wide_index)),
+            columns=pd.MultiIndex.from_frame(pd.DataFrame(expected_wide_columns)),
         )
         .reorder_levels(df.index.names, axis="index")  # allow different level orders
         .reorder_levels(df.columns.names, axis="columns")
@@ -90,111 +184,72 @@ def test_labeled_inventory_wide_format(tagged_fixture):
     assert_frame_equal(df, expected)
 
 
-def test_labeled_inventory_long_format(tagged_fixture):
+def test_labeled_inventory_narrow_format(tagged_fixture):
     act = get_activity(("foreground", "fu"))
     method = list(methods)[0]
     lca = LCA({act: 1}, method)
     lca.lci()
     se = get_labeled_inventory(lca, wide_format=False, usecols="all")
 
-    index = [
-        {
-            "source_id": 1,
-            "source_code": "bad",
-            "source_database": "biosphere",
-            "source_name": "bad",
-            "source_type": "emission",
-            "target_id": 3,
-            "target_code": "first",
-            "target_database": "background",
-        },
-        {
-            "source_id": 1,
-            "source_code": "bad",
-            "source_database": "biosphere",
-            "source_name": "bad",
-            "source_type": "emission",
-            "target_id": 4,
-            "target_code": "second",
-            "target_database": "background",
-        },
-        {
-            "source_id": 1,
-            "source_code": "bad",
-            "source_database": "biosphere",
-            "source_name": "bad",
-            "source_type": "emission",
-            "target_id": 6,
-            "target_code": "i",
-            "target_database": "foreground",
-            "target_secondary tag": "X",
-            "target_tag field": "A",
-        },
-        {
-            "source_id": 1,
-            "source_code": "bad",
-            "source_database": "biosphere",
-            "source_name": "bad",
-            "source_type": "emission",
-            "target_id": 6,
-            "target_code": "i",
-            "target_database": "foreground",
-            "target_secondary tag": "X",
-            "target_tag field": "A",
-        },
-        {
-            "source_id": 2,
-            "source_code": "worse",
-            "source_database": "biosphere",
-            "source_name": "worse",
-            "source_type": "emission",
-            "target_id": 7,
-            "target_code": "ii",
-            "target_database": "foreground",
-            "target_secondary tag": "X",
-            "target_tag field": "C",
-        },
-        {
-            "source_id": 2,
-            "source_code": "worse",
-            "source_database": "biosphere",
-            "source_name": "worse",
-            "source_type": "emission",
-            "target_id": 7,
-            "target_code": "ii",
-            "target_database": "foreground",
-            "target_secondary tag": "X",
-            "target_tag field": "C",
-        },
-        {
-            "source_id": 2,
-            "source_code": "worse",
-            "source_database": "biosphere",
-            "source_name": "worse",
-            "source_type": "emission",
-            "target_id": 8,
-            "target_code": "iii",
-            "target_database": "foreground",
-        },
-        {
-            "source_id": 2,
-            "source_code": "worse",
-            "source_database": "biosphere",
-            "source_name": "worse",
-            "source_type": "emission",
-            "target_id": 9,
-            "target_code": "iv",
-            "target_database": "foreground",
-            "target_secondary tag": "Y",
-            "target_tag field": "C",
-        },
+    expected_data = [27.0, 16.0, 5.0, 30.0, 44.0, 14.0, 6.0, 48.0]
+    expected = pd.Series(
+        data=expected_data,
+        index=pd.MultiIndex.from_frame(pd.DataFrame(expected_narrow_index)),
+        name="value",
+    )
+    assert_series_equal(se, expected)
+
+
+def test_labeled_characterized_inventory_before_lci(tagged_fixture):
+    act = get_activity(("foreground", "fu"))
+    method = list(methods)[0]
+    lca = LCA({act: 1}, method)
+    with pytest.raises(AssertionError) as e_info:
+        get_labeled_characterized_inventory(lca)
+
+
+def test_labeled_characterized_inventory_before_lcia(tagged_fixture):
+    act = get_activity(("foreground", "fu"))
+    method = list(methods)[0]
+    lca = LCA({act: 1}, method)
+    lca.lci()
+    with pytest.raises(AssertionError) as e_info:
+        get_labeled_characterized_inventory(lca)
+
+
+def test_labeled_characterized_inventory_wide_format(tagged_fixture):
+    act = get_activity(("foreground", "fu"))
+    method = list(methods)[0]
+    lca = LCA({act: 1}, method)
+    lca.lci()
+    lca.lcia()
+    df = get_labeled_characterized_inventory(lca, wide_format=True, usecols="all")
+    expected_data = [
+        [60.0, 0.0, 0.0, 10.0, 32.0, 54.0, 0.0],
+        [0.0, 144.0, 0.0, 18.0, 42.0, 0.0, 132.0],
     ]
-    data = [27., 16.,  5., 30., 44., 14.,  6., 48.]
     expected = (
-        pd.Series(
-            data=data,
-            index=pd.MultiIndex.from_frame(pd.DataFrame(index)),
-            name='value',
+        pd.DataFrame(
+            index=pd.MultiIndex.from_frame(pd.DataFrame(expected_wide_index)),
+            columns=pd.MultiIndex.from_frame(pd.DataFrame(expected_wide_columns)),
+            data=expected_data,
         )
+        .reorder_levels(df.index.names, axis="index")  # allow different level orders
+        .reorder_levels(df.columns.names, axis="columns")
+    )
+    assert_frame_equal(df, expected)
+
+def test_labeled_characterized_inventory_narrow_format(tagged_fixture):
+    act = get_activity(("foreground", "fu"))
+    method = list(methods)[0]
+    lca = LCA({act: 1}, method)
+    lca.lci()
+    lca.lcia()
+    se = get_labeled_characterized_inventory(lca, wide_format=False, usecols="all")
+    expected_data = [ 60.,  10.,  32.,  54., 144.,  18.,  42., 132.]
+    expected = pd.Series(
+        data=expected_data,
+        index=pd.MultiIndex.from_frame(pd.DataFrame(expected_narrow_index)),
+        name="value",
     )
     assert_series_equal(se, expected)

--- a/tests/lci.py
+++ b/tests/lci.py
@@ -4,7 +4,7 @@ from bw2calc import LCA
 from bw2analyzer.lci import get_labeled_inventory
 import pytest
 import pandas as pd
-from pandas.testing import assert_frame_equal
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 
 def test_labeled_inventory_before_lci(tagged_fixture):
@@ -15,20 +15,22 @@ def test_labeled_inventory_before_lci(tagged_fixture):
         get_labeled_inventory(lca)
 
 
-def test_labeled_inventory(tagged_fixture):
+def test_labeled_inventory_wide_format(tagged_fixture):
     act = get_activity(("foreground", "fu"))
     method = list(methods)[0]
     lca = LCA({act: 1}, method)
     lca.lci()
-    df = get_labeled_inventory(lca)
+    df = get_labeled_inventory(lca, wide_format=True, usecols="all")
+
+    assert isinstance(df, pd.DataFrame)
 
     rows = [
         {
+            "id": 1,
             "name": "bad",
             "type": "emission",
             "database": "biosphere",
             "code": "bad",
-            "id": 1,
         },
         {
             "name": "worse",
@@ -39,15 +41,15 @@ def test_labeled_inventory(tagged_fixture):
         },
     ]
     columns = [
-        {"database": "background", "code": "first", "id": 3},
+        {"id": 3, "database": "background", "code": "first"},
         {"database": "background", "code": "second", "id": 4},
         {
+            "id": 5,
             "name": "functional unit",
             "tag field": "functional unit",
             "secondary tag": "X",
             "database": "foreground",
             "code": "fu",
-            "id": 5,
         },
         {
             "tag field": "A",
@@ -76,9 +78,123 @@ def test_labeled_inventory(tagged_fixture):
         [30.0, 0.0, 0.0, 5.0, 16.0, 27.0, 0.0],
         [0.0, 48.0, 0.0, 6.0, 14.0, 0.0, 44.0],
     ]
-    expected = pd.DataFrame(
-        data=data,
-        index=pd.MultiIndex.from_frame(pd.DataFrame(rows)),
-        columns=pd.MultiIndex.from_frame(pd.DataFrame(columns)),
+    expected = (
+        pd.DataFrame(
+            data=data,
+            index=pd.MultiIndex.from_frame(pd.DataFrame(rows)),
+            columns=pd.MultiIndex.from_frame(pd.DataFrame(columns)),
+        )
+        .reorder_levels(df.index.names, axis="index")  # allow different level orders
+        .reorder_levels(df.columns.names, axis="columns")
     )
     assert_frame_equal(df, expected)
+
+
+def test_labeled_inventory_long_format(tagged_fixture):
+    act = get_activity(("foreground", "fu"))
+    method = list(methods)[0]
+    lca = LCA({act: 1}, method)
+    lca.lci()
+    se = get_labeled_inventory(lca, wide_format=False, usecols="all")
+
+    index = [
+        {
+            "source_id": 1,
+            "source_code": "bad",
+            "source_database": "biosphere",
+            "source_name": "bad",
+            "source_type": "emission",
+            "target_id": 3,
+            "target_code": "first",
+            "target_database": "background",
+        },
+        {
+            "source_id": 1,
+            "source_code": "bad",
+            "source_database": "biosphere",
+            "source_name": "bad",
+            "source_type": "emission",
+            "target_id": 4,
+            "target_code": "second",
+            "target_database": "background",
+        },
+        {
+            "source_id": 1,
+            "source_code": "bad",
+            "source_database": "biosphere",
+            "source_name": "bad",
+            "source_type": "emission",
+            "target_id": 6,
+            "target_code": "i",
+            "target_database": "foreground",
+            "target_secondary tag": "X",
+            "target_tag field": "A",
+        },
+        {
+            "source_id": 1,
+            "source_code": "bad",
+            "source_database": "biosphere",
+            "source_name": "bad",
+            "source_type": "emission",
+            "target_id": 6,
+            "target_code": "i",
+            "target_database": "foreground",
+            "target_secondary tag": "X",
+            "target_tag field": "A",
+        },
+        {
+            "source_id": 2,
+            "source_code": "worse",
+            "source_database": "biosphere",
+            "source_name": "worse",
+            "source_type": "emission",
+            "target_id": 7,
+            "target_code": "ii",
+            "target_database": "foreground",
+            "target_secondary tag": "X",
+            "target_tag field": "C",
+        },
+        {
+            "source_id": 2,
+            "source_code": "worse",
+            "source_database": "biosphere",
+            "source_name": "worse",
+            "source_type": "emission",
+            "target_id": 7,
+            "target_code": "ii",
+            "target_database": "foreground",
+            "target_secondary tag": "X",
+            "target_tag field": "C",
+        },
+        {
+            "source_id": 2,
+            "source_code": "worse",
+            "source_database": "biosphere",
+            "source_name": "worse",
+            "source_type": "emission",
+            "target_id": 8,
+            "target_code": "iii",
+            "target_database": "foreground",
+        },
+        {
+            "source_id": 2,
+            "source_code": "worse",
+            "source_database": "biosphere",
+            "source_name": "worse",
+            "source_type": "emission",
+            "target_id": 9,
+            "target_code": "iv",
+            "target_database": "foreground",
+            "target_secondary tag": "Y",
+            "target_tag field": "C",
+        },
+    ]
+    data = [27., 16.,  5., 30., 44., 14.,  6., 48.]
+    expected = (
+        pd.Series(
+            data=data,
+            index=pd.MultiIndex.from_frame(pd.DataFrame(index)),
+            name='value',
+        )
+    )
+    assert_series_equal(se, expected)


### PR DESCRIPTION
continued work on `get_labeled_inventory`
- [x] implemented helper functions to bulk load metadata from databases (addressing #15)
- [x] implemented switch to return labeled inventory data in wide or long format (addressing #13) 
- [x] implemented tests for long format
- [x] implement helper function to label characterized inventories (addressing #14 )

open issues:
- it might be worthwhile to store metadata in a cache to avoid loading it from the hard drive each time `get_labeled_inventory` is called. What is your opinion on this @cmutel ?
- should these helpers be accessible via `lca.inventory.to_dataframe()` and `lci.characterized_inventory.to_dataframe()`?