### PR TITLE
Add cumulative percentage mode + small changes

### DIFF
--- a/bw2analyzer/contribution.py
+++ b/bw2analyzer/contribution.py
@@ -4,11 +4,11 @@ from bw2data import get_activity
 
 
 class ContributionAnalysis:
-    def sort_array(self, data: np.array, limit: float = 25, limit_type: str = "number", total: Optional[float] = None):
+    def sort_array(self, data: np.array, limit: float = 25, limit_type: str = "number", total: Optional[float] = None) -> np.array:
         """
         Common sorting function for all ``top`` methods. Sorts by highest value first.
 
-        Operates in ``number``, ``percent_each`` or ``percent_all`` limit mode and ``abs`` or ``sum`` total mode.
+        Operates in ``number``, ``percent`` or ``cum_percent`` limit mode.
         In ``number`` mode, return ``limit`` values.
         In ``percent`` mode, return all values >= (total * limit); where ``0 < limit <= 1`` (e.g. any value over 5% of total).
         In ``cum_percent`` mode, return all values such that sum(values) >= (total * limit); where ``0 < limit <= 1`` (e.g. include all -sorted- values counting up (and first step over) limit).
@@ -44,8 +44,6 @@ class ContributionAnalysis:
             total = np.abs(data).sum()
         else:
             abs_total_flag = False
-
-        # total = total or np.abs(data).sum()
 
         if total == 0 and limit_type == "cum_percent":
             raise ValueError("Cumulative percentage cannot be calculated to a total of 0, use a different limit type or total")

--- a/bw2analyzer/contribution.py
+++ b/bw2analyzer/contribution.py
@@ -1,13 +1,17 @@
+from typing import Optional
 import numpy as np
 from bw2data import get_activity
 
 
 class ContributionAnalysis:
-    def sort_array(self, data, limit=25, limit_type="number", total=None):
+    def sort_array(self, data: np.array, limit: float = 25, limit_type: str = "number", total: Optional[float] = None):
         """
         Common sorting function for all ``top`` methods. Sorts by highest value first.
 
-        Operates in either ``number`` or ``percent`` mode. In ``number`` mode, return ``limit`` values. In ``percent`` mode, return all values >= (total * limit); where ``0 < limit <= 1``.
+        Operates in ``number``, ``percent_each`` or ``percent_all`` limit mode and ``abs`` or ``sum`` total mode.
+        In ``number`` mode, return ``limit`` values.
+        In ``percent`` mode, return all values >= (total * limit); where ``0 < limit <= 1`` (e.g. any value over 5% of total).
+        In ``cum_percent`` mode, return all values such that sum(values) >= (total * limit); where ``0 < limit <= 1`` (e.g. include all -sorted- values counting up (and first step over) limit).
 
         Returns 2-d numpy array of sorted values and row indices, e.g.:
 
@@ -28,25 +32,69 @@ class ContributionAnalysis:
         Args:
             * *data* (numpy array): A 1-d array of values to sort.
             * *limit* (number, default=25): Number of values to return, or percentage cutoff.
-            * *limit_type* (str, default=``number``): Either ``number`` or ``percent``.
+            * *limit_type* (str, default=``number``): Either ``number``, ``percent`` or ``cum_percent``.
             * *total* (number, default=None): Optional specification of summed data total.
 
         Returns:
             2-d numpy array of values and row indices.
 
         """
-        total = total or np.abs(data).sum()
-        if limit_type not in ("number", "percent"):
-            raise ValueError("limit_type must be either 'percent' or 'index'.")
-        if limit_type == "percent":
+        if not total:
+            abs_total_flag = True
+            total = np.abs(data).sum()
+        else:
+            abs_total_flag = False
+
+        # total = total or np.abs(data).sum()
+
+        if total == 0 and limit_type == "cum_percent":
+            raise ValueError("Cumulative percentage cannot be calculated to a total of 0, use a different limit type or total")
+
+        if limit_type not in ("number", "percent", "cum_percent"):
+            raise ValueError(f"limit_type must be either 'number', 'percent' or 'cum_percent' not '{limit_type}'.")
+        if limit_type  in ("percent", "cum_percent"):
             if not 0 < limit <= 1:
                 raise ValueError("Percentage limits > 0 and <= 1.")
-            limit = (np.abs(data) >= (total * limit)).sum()
 
         results = np.hstack(
             (data.reshape((-1, 1)), np.arange(data.shape[0]).reshape((-1, 1)))
         )
-        return results[np.argsort(np.abs(data))[::-1]][:limit, :]
+
+        if limit_type == "number":
+            # sort and cut off at limit
+            return results[np.argsort(np.abs(data))[::-1]][:limit, :]
+        elif limit_type == "percent":
+            # identify good values, drop rest and sort
+            limit = (np.abs(data) >= (abs(total) * limit))
+            results = results[limit, :]
+            return results[np.argsort(np.abs(results[:, 0]))[::-1]]
+        elif limit_type == "cum_percent" and abs_total_flag:
+            # if we would apply this on the 'correct' order, this would stop just before the limit,
+            # we want to be on or the first step over the limit.
+            results = results[np.argsort(np.abs(data))]  # sort low to high impact
+            cumsum = np.cumsum(np.abs(results[:, 0])) / abs(total)
+            limit = (cumsum >= (1 - limit))  # find items under limit
+            return results[limit, :][::-1]  # drop items under limit and set correct order
+        elif limit_type == "cum_percent" and not abs_total_flag:
+            # iterate over positive and negative values until limit is achieved or surpassed.
+            results = results[np.argsort(np.abs(data))][::-1]
+            pos_neg = [  # split into positive and negative sections
+                results[results[:, 0] > 0],
+                results[results[:, 0] < 0],
+            ]
+            # iterate over positive and negative sections
+            for i, arr in enumerate(pos_neg):
+                c = 0
+                # iterate over array until we have equalled or surpassed limit
+                for j, row in enumerate(arr):
+                    c += abs(row[0] / total)
+                    if c >= limit:
+                        break
+                arr = arr[:min(j + 1, len(arr)), :]
+                pos_neg[i] = arr
+
+            results = np.concatenate(pos_neg)  # rebuild into 1 array
+            return results[np.argsort(np.abs(results[:, 0]))][::-1]  # sort values
 
     def top_matrix(self, matrix, rows=5, cols=5):
         """

--- a/bw2analyzer/contribution.py
+++ b/bw2analyzer/contribution.py
@@ -40,19 +40,22 @@ class ContributionAnalysis:
 
         """
         if not total:
-            abs_total_flag = True
             total = np.abs(data).sum()
-        else:
-            abs_total_flag = False
 
         if total == 0 and limit_type == "cum_percent":
-            raise ValueError("Cumulative percentage cannot be calculated to a total of 0, use a different limit type or total")
+            raise ValueError(
+                "Cumulative percentage cannot be calculated to a total of 0, use a different limit type or total")
 
         if limit_type not in ("number", "percent", "cum_percent"):
             raise ValueError(f"limit_type must be either 'number', 'percent' or 'cum_percent' not '{limit_type}'.")
-        if limit_type  in ("percent", "cum_percent"):
+        if limit_type in ("percent", "cum_percent"):
             if not 0 < limit <= 1:
                 raise ValueError("Percentage limits > 0 and <= 1.")
+        if limit_type == "number":
+            if not int(limit) == limit:
+                raise ValueError("Number limit must a whole number.")
+            if not 0 < limit:
+                raise ValueError("Number limit must be < 0.")
 
         results = np.hstack(
             (data.reshape((-1, 1)), np.arange(data.shape[0]).reshape((-1, 1)))
@@ -66,33 +69,13 @@ class ContributionAnalysis:
             limit = (np.abs(data) >= (abs(total) * limit))
             results = results[limit, :]
             return results[np.argsort(np.abs(results[:, 0]))[::-1]]
-        elif limit_type == "cum_percent" and abs_total_flag:
+        elif limit_type == "cum_percent":
             # if we would apply this on the 'correct' order, this would stop just before the limit,
             # we want to be on or the first step over the limit.
             results = results[np.argsort(np.abs(data))]  # sort low to high impact
             cumsum = np.cumsum(np.abs(results[:, 0])) / abs(total)
             limit = (cumsum >= (1 - limit))  # find items under limit
             return results[limit, :][::-1]  # drop items under limit and set correct order
-        elif limit_type == "cum_percent" and not abs_total_flag:
-            # iterate over positive and negative values until limit is achieved or surpassed.
-            results = results[np.argsort(np.abs(data))][::-1]
-            pos_neg = [  # split into positive and negative sections
-                results[results[:, 0] > 0],
-                results[results[:, 0] < 0],
-            ]
-            # iterate over positive and negative sections
-            for i, arr in enumerate(pos_neg):
-                c = 0
-                # iterate over array until we have equalled or surpassed limit
-                for j, row in enumerate(arr):
-                    c += abs(row[0] / total)
-                    if c >= limit:
-                        break
-                arr = arr[:min(j + 1, len(arr)), :]
-                pos_neg[i] = arr
-
-            results = np.concatenate(pos_neg)  # rebuild into 1 array
-            return results[np.argsort(np.abs(results[:, 0]))][::-1]  # sort values
 
     def top_matrix(self, matrix, rows=5, cols=5):
         """

--- a/tests/contribution.py
+++ b/tests/contribution.py
@@ -51,12 +51,92 @@ class ContributionTestCase(unittest.TestCase):
             )
         )
 
+    def test_sort_array_percentage_negative_sum(self):
+        test_data = np.array((1.0, -2.0, 4.0, 3.0))
+        answer = np.array(
+            (
+                (4, 2),
+                (3, 3),
+                (-2, 1),
+            )
+        )
+        ca = CA()
+        self.assertTrue(
+            np.allclose(
+                answer, ca.sort_array(test_data, limit=0.3, limit_type="percent", total=test_data.sum())
+            )
+        )
+
+    def test_sort_array_percentage_true_negative_sum(self):
+        test_data = np.array((-1.0, 2.0, -4.0, -3.0))
+        answer = np.array(
+            (
+                (-4, 2),
+                (-3, 3),
+                (2, 1),
+            )
+        )
+        ca = CA()
+        self.assertTrue(
+            np.allclose(
+                answer, ca.sort_array(test_data, limit=0.3, limit_type="percent", total=test_data.sum())
+            )
+        )
+
+    def test_sort_array_cum_percentage(self):
+        test_data = np.array((1.0, 2.0, 4.0, 3.0))
+        answer = np.array(
+            (
+                (4, 2),
+                (3, 3),
+                (2, 1),
+            )
+        )
+        ca = CA()
+        self.assertTrue(
+            np.allclose(
+                answer, ca.sort_array(test_data, limit=0.8, limit_type="cum_percent")
+            )
+        )
+
+    def test_sort_array_cum_percentage_negative(self):
+        test_data = np.array((1.0, 2.0, -4.0, 3.0))
+        answer = np.array(
+            (
+                (-4, 2),
+                (3, 3),
+                (2, 1)
+            )
+        )
+        ca = CA()
+        self.assertTrue(
+            np.allclose(
+                answer, ca.sort_array(test_data, limit=0.8, limit_type="cum_percent")
+            )
+        )
+
+    def test_sort_array_cum_percentage_negative_sum(self):
+        test_data = np.array((1.0, -2.0, 4.0, 3.0))
+        answer = np.array(
+            (
+                (4, 2),
+                (3, 3),
+                (-2, 1)
+            )
+        )
+        ca = CA()
+        self.assertTrue(
+            np.allclose(
+                answer, ca.sort_array(test_data, limit=0.8, limit_type="cum_percent", total=test_data.sum())
+            )
+        )
+
     def test_sort_array_errors(self):
         ca = CA()
         with self.assertRaises(ValueError):
             ca.sort_array([], limit_type="foo", total=1.0)
         with self.assertRaises(ValueError):
-            ca.sort_array([], limit=0.0, limit_type="percent", total=1.0)
+            ca.sort_array([], limit=-0.01, limit_type="percent", total=1.0)
         with self.assertRaises(ValueError):
             ca.sort_array([], limit=1.01, limit_type="percent", total=1.0)
 


### PR DESCRIPTION
Fix negative results bug + add new cumulative percentage mode to sort_array + add tests

- Fix bug in `sort_array` in `percent` mode when total summed result would be negative and contributions would be negative by taking abs() of total
- Fix bug in `sort_array` in `percent` mode where negative total would make `limit` negative and thus return a slice to negative limit (e.g. in list of 10k items, and `limit` becomes 10, then list size would become [:-10], meaning len 9990 instead of 10)
- Add tests for bugs
- Add new mode to 'sort_array' for counting cumulative percentages (see below)
- substantially increase speed of 'percent' mode by sorting _after_ dropping non-matching results
- Add more tests for new mode and other variations in 'sort_array'
- Add type hinting to sort_array

### cumulative percentage mode for sort_array
This PR adds a new mode to sort_array to get all values to a cumulative percentage.

`percent` mode takes all values that are `limit`% or higher. `cum_percent` mode instead cumulatively counts all percentages to `limit`. An example could be the EF Hotspot assessment requirement ([chapter 6.3](https://eplca.jrc.ec.europa.eu/permalink/PEF_method.pdf)), where the top 80% items _must_ be shown.